### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/part-2.ipynb
+++ b/part-2.ipynb
@@ -614,22 +614,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2023-11-27 14:25:40--  https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json\n",
+      "--2023-11-27 14:25:40--  https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json\n",
       "Resolving hugovk.github.io (hugovk.github.io)... 185.199.109.153, 185.199.108.153, 185.199.111.153, ...\n",
       "Connecting to hugovk.github.io (hugovk.github.io)|185.199.109.153|:443... connected.\n",
       "HTTP request sent, awaiting response... 200 OK\n",
       "Length: 411246 (402K) [application/json]\n",
-      "Saving to: ‘top-pypi-packages-30-days.min.json.1’\n",
+      "Saving to: ‘top-pypi-packages.min.json.1’\n",
       "\n",
       "top-pypi-packages-3 100%[===================>] 401,61K  1,14MB/s    in 0,3s    \n",
       "\n",
-      "2023-11-27 14:25:40 (1,14 MB/s) - ‘top-pypi-packages-30-days.min.json.1’ saved [411246/411246]\n",
+      "2023-11-27 14:25:40 (1,14 MB/s) - ‘top-pypi-packages.min.json.1’ saved [411246/411246]\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "! wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json"
+    "! wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json"
    ]
   },
   {
@@ -659,7 +659,7 @@
     }
    ],
    "source": [
-    "package_names = [ex[\"project\"] for ex in srsly.read_json(\"top-pypi-packages-30-days.min.json\")[\"rows\"]]\n",
+    "package_names = [ex[\"project\"] for ex in srsly.read_json(\"top-pypi-packages.min.json\")[\"rows\"]]\n",
     "package_names[:10]"
    ]
   },


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.